### PR TITLE
Small correction at the Add auth key route

### DIFF
--- a/source/includes/_platform.md
+++ b/source/includes/_platform.md
@@ -120,7 +120,7 @@ Adds a new auth key to the permitted auth keys for user's of this application, c
 
 ### HTTP Request
 
-`POST https://api.doordeck.com/platform/application/APPLICATION_ID/key`
+`POST https://api.doordeck.com/platform/application/APPLICATION_ID/auth/key`
 
 ### Request Parameters
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->