### PR TITLE
Document Get Lock Belonging to Tile V2 & V3 Endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
         build-essential \
         git \
         nodejs \
-    && gem install bundler \
+    && gem install bundler -v 2.4.22 \
     && bundle install \
     && apt-get remove -y build-essential git \
     && apt-get autoremove -y \

--- a/slate.sh
+++ b/slate.sh
@@ -31,7 +31,7 @@ Deploy options:
 
 
 run_serve() {
-  exec bundle exec middleman serve --watcher-force-polling
+  exec bundle exec middleman serve --bind-address=0.0.0.0 --watcher-force-polling
 }
 
 run_build() {

--- a/source/includes/_operations.md
+++ b/source/includes/_operations.md
@@ -889,30 +889,6 @@ timezone | true | Timezone, e.g. Europe/London, describing what hours the start 
 days | true | List of days the time window applies, e.g. MONDAY, TUESDAY
 exceptions | false | List of dates (YYYY-MM-DD) to ignore above settings, useful for holidays
 
-## Monitor Real-time Lock State
-
-```shell
-curl "https://api.doordeck.com/device/events?device=00000000-0000-0000-0000-000000000000"
-  -H "Authorization: Bearer TOKEN"
-```
-
-> Replace `00000000-0000-0000-0000-000000000000` with the lock's ID
-
-This is a [Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) endpoint that takes multiple devices and returns a stream of events.
-
-<aside class="notice">
-This endpoint is experimental and may change without notice.
-</aside>
-
-### HTTP Request
-`GET https://api.doordeck.com/device/events?device=00000000-0000-0000-0000-000000000000`
-
-### Query Parameters
-
-Parameter | Required | Description
---------- | ------- | -----------
-device | true | Device ID to monitor, multiple can specified as separate query parameters
-
 ## Get Pinned Locks
 
 ```shell

--- a/source/includes/_tile.md
+++ b/source/includes/_tile.md
@@ -32,6 +32,13 @@ curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
 > The above command returns 404 if no tile is known, or a see other 303 with the `Location` header set to the value of
 the lock
 
+> On success, it returns a json structured like this:
+```json
+{
+  "deviceId": "device-uuid"
+}
+```
+
 This endpoint identifies which lock belongs to the specific tile.
 
 This call must be made with the `Accept` header set to `application/vnd.doordeck.api-v2+json`.
@@ -53,6 +60,18 @@ curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
 
 > The above command returns 404 if no tile is known, or a see other 303 with the `Location` header set to the value of
 the lock
+
+> On success, it returns a json structured like this:
+```json
+{
+    "siteId": "site-uuid",
+    "tileId": "tile-uuid",
+    "deviceIds": [
+      "device-uuid-1",
+      "device-uuid-2"
+    ]
+}
+```
 
 This endpoint identifies which lock belongs to the specific tile.
 

--- a/source/includes/_tile.md
+++ b/source/includes/_tile.md
@@ -1,6 +1,10 @@
 # Tiles
 
-## Get Lock Belonging To Tile
+## Get Lock Belonging To Tile (v1)
+
+<aside class="warning">
+This endpoint is marked for deprecation. Please refer to v3 for the latest version.
+</aside>
 
 ```shell
 curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
@@ -22,17 +26,19 @@ Replace `TILE_ID` with the appropriate tile ID.
 
 ## Get Lock Belonging To Tile (v2)
 
+<aside class="warning">
+This endpoint is marked for deprecation. Please refer to v3 for the latest version.
+</aside>
+
 ```shell
 curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
+  -H "Accept: application/vnd.doordeck.api-v2+json"
   -H "Authorization: Bearer TOKEN"
 ```
 
 > Replace `00000000-0000-0000-0000-000000000000` with the tile ID.
 
-> The above command returns 404 if no tile is known, or a see other 303 with the `Location` header set to the value of
-the lock
-
-> On success, it returns a json structured like this:
+> The above command returns a JSON structured as follows:
 ```json
 {
   "deviceId": "device-uuid"
@@ -53,15 +59,13 @@ Replace `TILE_ID` with the appropriate tile ID.
 
 ```shell
 curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
+  -H "Accept: application/vnd.doordeck.api-v3+json"
   -H "Authorization: Bearer TOKEN"
 ```
 
 > Replace `00000000-0000-0000-0000-000000000000` with the tile ID.
 
-> The above command returns 404 if no tile is known, or a see other 303 with the `Location` header set to the value of
-the lock
-
-> On success, it returns a json structured like this:
+> The above command returns a JSON structured as follows:
 ```json
 {
     "siteId": "site-uuid",

--- a/source/includes/_tile.md
+++ b/source/includes/_tile.md
@@ -20,6 +20,50 @@ This endpoint identifies which lock belongs to the specific tile.
 
 Replace `TILE_ID` with the appropriate tile ID.
 
+## Get Lock Belonging To Tile (v2)
+
+```shell
+curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
+  -H "Authorization: Bearer TOKEN"
+```
+
+> Replace `00000000-0000-0000-0000-000000000000` with the tile ID.
+
+> The above command returns 404 if no tile is known, or a see other 303 with the `Location` header set to the value of
+the lock
+
+This endpoint identifies which lock belongs to the specific tile.
+
+This call must be made with the `Accept` header set to `application/vnd.doordeck.api-v2+json`.
+
+### HTTP Request
+
+`GET https://api.doordeck.com/tile/TILE_ID/`
+
+Replace `TILE_ID` with the appropriate tile ID.
+
+## Get Lock Belonging To Tile (v3)
+
+```shell
+curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
+  -H "Authorization: Bearer TOKEN"
+```
+
+> Replace `00000000-0000-0000-0000-000000000000` with the tile ID.
+
+> The above command returns 404 if no tile is known, or a see other 303 with the `Location` header set to the value of
+the lock
+
+This endpoint identifies which lock belongs to the specific tile.
+
+This call must be made with the `Accept` header set to `application/vnd.doordeck.api-v3+json`.
+
+### HTTP Request
+
+`GET https://api.doordeck.com/tile/TILE_ID/`
+
+Replace `TILE_ID` with the appropriate tile ID.
+
 ## Associate Tile With Lock
 
 ```shell

--- a/source/includes/_tile.md
+++ b/source/includes/_tile.md
@@ -39,6 +39,7 @@ curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
 > Replace `00000000-0000-0000-0000-000000000000` with the tile ID.
 
 > The above command returns a JSON structured as follows:
+
 ```json
 {
   "deviceId": "device-uuid"
@@ -55,7 +56,7 @@ This call must be made with the `Accept` header set to `application/vnd.doordeck
 
 Replace `TILE_ID` with the appropriate tile ID.
 
-## Get Lock Belonging To Tile (v3)
+## Get Locks Belonging To Tile (v3)
 
 ```shell
 curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
@@ -66,6 +67,7 @@ curl 'https://api.doordeck.com/tile/00000000-0000-0000-0000-000000000000/'
 > Replace `00000000-0000-0000-0000-000000000000` with the tile ID.
 
 > The above command returns a JSON structured as follows:
+
 ```json
 {
     "siteId": "site-uuid",


### PR DESCRIPTION
This PR adds documentation for the newly added APIs for retrieving a lock that belongs to a tile for v2 and v3.

Will solve this issue: https://github.com/doordeck/docs/issues/47