### PR TITLE
Add missing get a single lock version header

### DIFF
--- a/source/includes/_operations.md
+++ b/source/includes/_operations.md
@@ -91,6 +91,7 @@ This endpoint retrieves all locks a user has access to.
 
 ```shell
 curl 'https://api.doordeck.com/device/00000000-0000-0000-0000-000000000000'
+  -H "Accept: application/vnd.doordeck.api-v3+json"
   -H "Authorization: Bearer TOKEN"
 ```
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->