### PR TITLE
Removing the Doordeck issued auth tokens warning from the refresh token

### DIFF
--- a/source/includes/_account.md
+++ b/source/includes/_account.md
@@ -233,10 +233,6 @@ A validation email will be disptahced to the user's email address upon successfu
 
 ## Refresh Token
 
-<aside class="warning">
-This endpoint is only available to users with Doordeck issued auth tokens.
-</aside>
-
 ```shell
 curl -X POST "https://api.doordeck.com/auth/token/refresh"
   -H "Authorization: Bearer REFRESH_TOKEN"


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->