### PR TITLE
Invalidate cloudfront cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: 'ROLE'
+          role-to-assume: 'arn:aws:iam::135184807345:role/GitHubAction-DocsRelease'
           aws-region: eu-west-1
 
       - name: Install dependencies


### PR DESCRIPTION
This has been driving me crazy since last Friday because the docs were working fine in some browsers but not in others. Apparently, invalidating the CloudFront caches resolved the issue, so we’ll do it after each deploy.

Note: Let me know which role we should use